### PR TITLE
Fix detached cooldown groups only showing spells for arena1

### DIFF
--- a/modules/cooldowns.lua
+++ b/modules/cooldowns.lua
@@ -781,7 +781,7 @@ function Cooldowns:UpdateGroupIcons(unit, group)
 	local gs = self:GetGroupState(unit, group)
 	local db = Cooldowns:GetGroupDB(unit, group)
 
-	if not gs.frame then return end
+	if not gs.frame and not db.cooldownsDetached then return end
 
 	-- get spells lists
 	local sorted_spells = GetCooldownList(unit, group)


### PR DESCRIPTION
Currently, detached cooldown groups seem to only show the cooldowns for arena1. This can be fixed by disabling- and re-enabling the `Detached Group`, but only until you reload. 

A related issue: https://www.curseforge.com/wow/addons/gladiusex/issues/92

It seems the spells for `arena2` and `arena3` were not being updated, because `gs.frame` was never set for them (unless you've had the `Detached Group` option disabled earlier that session).

This change allows `UpdateGroupIcons` to fully run for all units, not just `arena1`.