### PR TITLE
Use maintained LibRangeCheck

### DIFF
--- a/.pkgmeta
+++ b/.pkgmeta
@@ -32,7 +32,7 @@ externals:
   libs/LibGroupInSpecT-1.1:
     url: svn://svn.wowace.com/wow/libgroupinspect/mainline/trunk
   libs/LibRangeCheck-2.0:
-    url: svn://svn.wowace.com/wow/librangecheck-2-0/mainline/trunk
+    url: https://github.com/WeakAuras/LibRangeCheck-2.0
   libs/LibSharedMedia-3.0:
     url: svn://svn.wowace.com/wow/libsharedmedia-3-0/mainline/trunk
   libs/LibCooldownTracker-1.0:


### PR DESCRIPTION
This is the fix basically proposed by #68 

The current library of LibRangeCheck on WowAce and CF is pre-DF and has a massively inflated minor version `100000000000001` or so. This forces this out of date version to take priority in LibStub. Breaking all addons that use it while a user is using GladiusEx or any other addon with the bad version. The WA/ElvUI team have a working version of the library that they have been maintaining, with a more sane version number as well.


I don't believe there is any methods required on your end to fix this PR. It should be a 'drag and drop' style replacement. As the Author/Uploader, you would know for sure.