### PR TITLE
Update templates.xml

### DIFF
--- a/templates.xml
+++ b/templates.xml
@@ -23,7 +23,6 @@
         -->
 			</Layer>
 			<Layer level="ARTWORK" textureSubLevel="2">
-				<Texture name="$parentFlyoutArrow" inherits="ActionBarFlyoutButton-ArrowUp" parentKey="FlyoutArrow" hidden="true"/>
 				<FontString name="$parentHotKey" inherits="NumberFontNormalSmallGray" parentKey="HotKey" justifyH="RIGHT">
 					<Size x="36" y="10"/>
 					<Anchors>


### PR DESCRIPTION
The removed line causes a lua error on every arena entry (or by clicking "Test 3v3"). It refers to a texture that no longer exists, and was removed with the UI update. 

I considered replacing it with the new equivalent texture, but after looking through the code, it doesn't appear we use it anywhere. 

Additionally, the texture is set to be hidden, and there doesn't seem to be anywhere we un-hide it in the code. I propose we remove this texture, unless there is a reason for it that I couldn't find. 

This PR removes an outdated texture inheritance, and fixes a common error cause.

If we do want to replace the texture, it looks like it's: 

MainMenuBar.ActionBarPageNumber.UpButton.1699ca861c0
or Atlas:UI-HUD-ActionBar-PageUpArrow-Up

