### PR TITLE
Update LibRangeCheck to 3.0

### DIFF
--- a/.pkgmeta
+++ b/.pkgmeta
@@ -31,8 +31,8 @@ externals:
     url: https://github.com/slaren/LibFunctional-1.0
   libs/LibGroupInSpecT-1.1:
     url: svn://svn.wowace.com/wow/libgroupinspect/mainline/trunk
-  libs/LibRangeCheck-2.0:
-    url: https://github.com/WeakAuras/LibRangeCheck-2.0
+  libs/LibRangeCheck-3.0:
+    url: https://github.com/WeakAuras/LibRangeCheck-3.0
   libs/LibSharedMedia-3.0:
     url: svn://svn.wowace.com/wow/libsharedmedia-3-0/mainline/trunk
   libs/LibCooldownTracker-1.0:

--- a/GladiusEx-BCC.toc
+++ b/GladiusEx-BCC.toc
@@ -2,7 +2,7 @@
 ## Title: GladiusEx
 ## Notes: Arena unit frames and more
 ## SavedVariables: GladiusExDB
-## OptionalDeps: Ace3, DRList-1.0, LibSharedMedia-3.0, LibGroupInSpecT-1.1, LibCooldownTracker-1.0, LibFunctional-1.0, LibCustomGlow-1.0, Clique, Masque, LibDualSpec-1.0, LibRangeCheck-2.0, LibDispellable-1.0, AceGUI-3.0-SharedMediaWidgets
+## OptionalDeps: Ace3, DRList-1.0, LibSharedMedia-3.0, LibGroupInSpecT-1.1, LibCooldownTracker-1.0, LibFunctional-1.0, LibCustomGlow-1.0, Clique, Masque, LibDualSpec-1.0, LibRangeCheck-3.0, LibDispellable-1.0, AceGUI-3.0-SharedMediaWidgets
 ## X-Curse-Project-ID: 45973
 ## X-Wago-ID: 2jK8q5Gy
 

--- a/GladiusEx-Wrath.toc
+++ b/GladiusEx-Wrath.toc
@@ -2,7 +2,7 @@
 ## Title: GladiusEx
 ## Notes: Arena unit frames and more
 ## SavedVariables: GladiusExDB
-## OptionalDeps: Ace3, DRList-1.0, LibSharedMedia-3.0, LibCooldownTracker-1.0, LibFunctional-1.0, LibCustomGlow-1.0, Clique, Masque, LibDualSpec-1.0, LibRangeCheck-2.0, LibDispellable-1.0, AceGUI-3.0-SharedMediaWidgets
+## OptionalDeps: Ace3, DRList-1.0, LibSharedMedia-3.0, LibCooldownTracker-1.0, LibFunctional-1.0, LibCustomGlow-1.0, Clique, Masque, LibDualSpec-1.0, LibRangeCheck-3.0, LibDispellable-1.0, AceGUI-3.0-SharedMediaWidgets
 ## X-Curse-Project-ID: 45973
 ## X-Wago-ID: 2jK8q5Gy
 

--- a/GladiusEx.lua
+++ b/GladiusEx.lua
@@ -7,7 +7,7 @@ GladiusEx.IS_CLASSIC = GladiusEx.IS_TBCC or GladiusEx.IS_WOTLKC
 
 local LGIST = GladiusEx.IS_RETAIL and LibStub:GetLibrary("LibGroupInSpecT-1.1")
 local L = LibStub("AceLocale-3.0"):GetLocale("GladiusEx")
-local RC = LibStub("LibRangeCheck-2.0")
+local RC = LibStub("LibRangeCheck-3.0")
 local LSM = LibStub("LibSharedMedia-3.0")
 local fn = LibStub("LibFunctional-1.0")
 

--- a/GladiusEx.toc
+++ b/GladiusEx.toc
@@ -2,7 +2,7 @@
 ## Title: GladiusEx
 ## Notes: Arena unit frames and more
 ## SavedVariables: GladiusExDB
-## OptionalDeps: Ace3, DRList-1.0, LibSharedMedia-3.0, LibGroupInSpecT-1.1, LibCooldownTracker-1.0, LibFunctional-1.0, LibCustomGlow-1.0, Clique, Masque, LibDualSpec-1.0, LibRangeCheck-2.0, LibDispellable-1.0, AceGUI-3.0-SharedMediaWidgets
+## OptionalDeps: Ace3, DRList-1.0, LibSharedMedia-3.0, LibGroupInSpecT-1.1, LibCooldownTracker-1.0, LibFunctional-1.0, LibCustomGlow-1.0, Clique, Masque, LibDualSpec-1.0, LibRangeCheck-3.0, LibDispellable-1.0, AceGUI-3.0-SharedMediaWidgets
 ## X-Curse-Project-ID: 45973
 ## X-Wago-ID: 2jK8q5Gy
 

--- a/embeds-bcc.xml
+++ b/embeds-bcc.xml
@@ -14,7 +14,7 @@
 	<Include file="libs\AceConfig-3.0\AceConfig-3.0.xml"/>
 	<Include file="libs\AceLocale-3.0\AceLocale-3.0.xml"/>
 	<Include file="libs\AceSerializer-3.0\AceSerializer-3.0.xml"/>
-	<Include file="libs\LibRangeCheck-2.0\LibRangeCheck-2.0\LibRangeCheck-2.0.lua"/>
+	<Include file="libs\LibRangeCheck-3.0\LibRangeCheck-3.0\LibRangeCheck-3.0.lua"/>
 	<Include file="libs\LibDispellable-1.0\LibDispellable-1.0.lua"/>
 	<Include file="libs\LibGroupInSpecT-1.1\lib.xml"/>
 	<Include file="libs\LibCooldownTracker-1.0\lib-bcc.xml"/>

--- a/embeds-wrath.xml
+++ b/embeds-wrath.xml
@@ -14,7 +14,7 @@
 	<Include file="libs\AceConfig-3.0\AceConfig-3.0.xml"/>
 	<Include file="libs\AceLocale-3.0\AceLocale-3.0.xml"/>
 	<Include file="libs\AceSerializer-3.0\AceSerializer-3.0.xml"/>
-	<Include file="libs\LibRangeCheck-2.0\LibRangeCheck-2.0\LibRangeCheck-2.0.lua"/>
+	<Include file="libs\LibRangeCheck-3.0\LibRangeCheck-3.0\LibRangeCheck-3.0.lua"/>
 	<Include file="libs\LibDispellable-1.0\LibDispellable-1.0.lua"/>
 	<Include file="libs\LibCooldownTracker-1.0\lib-wrath.xml"/>
 	<Include file="libs\LibCustomGlow-1.0\LibCustomGlow-1.0.xml"/>

--- a/embeds.xml
+++ b/embeds.xml
@@ -15,7 +15,7 @@
 	<Include file="libs\AceLocale-3.0\AceLocale-3.0.xml"/>
 	<Include file="libs\AceSerializer-3.0\AceSerializer-3.0.xml"/>
 	<Include file="libs\LibDualSpec-1.0\LibDualSpec-1.0.lua"/>
-	<Include file="libs\LibRangeCheck-2.0\LibRangeCheck-2.0\LibRangeCheck-2.0.lua"/>
+	<Include file="libs\LibRangeCheck-3.0\LibRangeCheck-3.0\LibRangeCheck-3.0.lua"/>
 	<Include file="libs\LibDispellable-1.0\LibDispellable-1.0.lua"/>
 	<Include file="libs\LibGroupInSpecT-1.1\lib.xml"/>
 	<Include file="libs\LibCooldownTracker-1.0\lib.xml"/>


### PR DESCRIPTION
In 10.2 Blizzard has protected some range checking causing LibRangeCheck-2.0 to be deprecated.