### PR TITLE
Spec detection by Mana

### DIFF
--- a/Data-Cata.lua
+++ b/Data-Cata.lua
@@ -648,6 +648,8 @@ GladiusEx.Data.AuraDurations = {
     [22570] = 5, -- Maim (varies)
 }
 
+GladiusEx.Data.SpecManaLimit = 50000
+
 function GladiusEx.Data.GetSpecializationInfoByID(id)
     if specData[id] == nil then
         return

--- a/Data-Wrath.lua
+++ b/Data-Wrath.lua
@@ -552,6 +552,8 @@ GladiusEx.Data.SpecSpells = {
     [53251] = 105, -- Wild Growth
 }
 
+GladiusEx.Data.SpecManaLimit = 11000
+
 function GladiusEx.Data.GetSpecializationInfoByID(id)
     if specData[id] == nil then
         return

--- a/GladiusEx.lua
+++ b/GladiusEx.lua
@@ -739,12 +739,40 @@ function GladiusEx:CheckOpponentSpecialization(unit)
     if id then
         local specID = GladiusEx.Data.GetArenaOpponentSpec(tonumber(id))
 
-        if GladiusEx.IS_CLASSIC and not specID then
-            specID = self:FindSpecByAuras(unit)
+        if not specID and GladiusEx.IS_CLASSIC then
+			
+			-- K: TBC healer / hybrid mana pools are too similar to use this method
+			if not GladiusEx.IS_TBCC then
+				specID = self:FindSpecByPower(unit)
+			end
+			
+			if not specID then
+				specID = self:FindSpecByAuras(unit)
+			end
         end
 
         self:UpdateUnitSpecialization(unit, specID)
     end
+end
+
+function GladiusEx:FindSpecByPower(unit)
+	local _, class = UnitClass(unit)
+	local specID
+	if class then
+		local p = UnitPowerMax(unit, 0)
+		local limit = GladiusEx.Data.SpecManaLimit
+		if p then
+			if class == "PALADIN" and p > limit then
+				specID = 65 -- Holy
+			elseif class == "DRUID" and p < limit then
+				specID = 103 -- Feral
+			elseif class == "SHAMAN" and p < limit then
+				specID = 263 -- Enhancement
+			end
+		end
+	end
+	
+	return specID
 end
 
 function GladiusEx:FindSpecByAuras(unit)


### PR DESCRIPTION
For example. Holy Paladins are the only Paladin spec with > 50000 mana in Cata (similar logic applies to the other specs in this commit).

Included WotLK mana pools as well, but excluded TBC because the pools between hybrid and healer specs are too close.