### PR TITLE
Fix Player CD is missing

### DIFF
--- a/modules/cooldowns.lua
+++ b/modules/cooldowns.lua
@@ -592,6 +592,14 @@ local function GetUnitInfo(unit)
         covenant = GladiusEx.testing[unit].covenant
     elseif GladiusEx.buttons[unit] then
         specID = GladiusEx.buttons[unit].specID
+
+        if unit == "player" and C_SpecializationInfo and C_SpecializationInfo.GetSpecialization then
+            local currentSpec = C_SpecializationInfo.GetSpecialization()
+            if currentSpec and C_SpecializationInfo.GetSpecializationInfo then
+                specID = C_SpecializationInfo.GetSpecializationInfo(currentSpec)
+            end
+        end
+
         class = GladiusEx.buttons[unit].class or select(2, UnitClass(unit))
         race = select(2, UnitRace(unit))
         covenant = GladiusEx.buttons[unit].covenant


### PR DESCRIPTION
Hello, please review, I'm not an expert at all, so it is needed to double check potential pitfalls. 

The problem is that player's cds that depends on specialization are not shown for player. The reason behind this is because specID for player is nil and later `spell_list` doesn't contain spells belong to spec, so I set value for it.

Before fix:
<img width="243" height="109" alt="image" src="https://github.com/user-attachments/assets/0f458068-d361-4a29-bcda-98373ba09451" />
After fix: Yes, Nature's Swiftness works as well :)
<img width="285" height="116" alt="image" src="https://github.com/user-attachments/assets/abde5b87-40d7-4070-bb2c-3407153cb350" />

Considerations:
1. First of all, I was trying to find maybe `GladiusEx.buttons[PLAYER]` is populated somewhere but didn't find anything. Theoretically, it would be nice to do player's prerequisites on some initialization step, but I'm not sure.
2. Believe me or not, yesterday it worked without `C_SpecializationInfo` namespace, just pure function call, I was surprised that I couldn't open addon UI in the morning. But this fact encouraged me do additional checks for functions existence to not ruin addon for other clients.
3. Speaking of breaking changes, I'm also not sure what's the impact might be, is it worth to add MoP check or something else?
