### PR TITLE
Fix Taint in ClassIcon

### DIFF
--- a/modules/classicon.lua
+++ b/modules/classicon.lua
@@ -3,7 +3,8 @@ local L = LibStub("AceLocale-3.0"):GetLocale("GladiusEx")
 local fn = LibStub("LibFunctional-1.0")
 local LSM = LibStub("LibSharedMedia-3.0")
 
-function GetTexCoordsForRole(role)
+-- K: Is this even needed anymore? Can't test on retail but it seems to stem from a beta workaround. It's causing taint in the talent frame in Classic.
+local function GetTexCoordsForRole(role)
 	local textureHeight, textureWidth = 256, 256
 	local roleHeight, roleWidth = 67, 67
 	
@@ -861,3 +862,4 @@ function ClassIcon:SetupAuraOptions(options, unit, aura)
 		},
 	}
 end
+


### PR DESCRIPTION
So, after a lot of debugging I think I finally figured out what's been causing the taint in MoP Classic. GetTexCoordsForRole is used heavily in https://github.com/Gethe/wow-ui-source/blob/live/Interface/AddOns/Blizzard_TalentUI/Mists/Blizzard_TalentUI.lua (i.e. MoP talent frame). Making our version of the function local fixes the issue, but I think it's probably not even needed anymore (looking at the blame it seems to stem from TWW beta workarounds).